### PR TITLE
Set up PubSub for GraphQL

### DIFF
--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/config/config.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/config/config.exs
@@ -7,6 +7,7 @@ config :<%= @project_name %>, ecto_repos: [<%= @project_name_camel_case %>.Repo]
 <%= if assigns[:websockets] do %>
 config :<%= @project_name %>, <%= @project_name_camel_case %>.PubSub,
   adapter: Phoenix.PubSub.PG2,
+  fastlane: Phoenix.Channel.Server,
   pool_size: 10
 <% end %>
 

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/application.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/application.ex
@@ -13,7 +13,11 @@ defmodule <%= @project_name_camel_case %>.Application do
     Supervisor.start_link([
       <%= if assigns[:ecto] do %>
       supervisor(<%= @project_name_camel_case %>.Repo, []),
-      <% else %>
+      <% end %>
+      <%= if assigns[:websockets] do %>
+      <%= @project_name_camel_case %>.PubSub,
+      <% end %>
+      <%= unless assigns[:websockets] || assigns[:ecto] do %>
       # worker(module, args)
       <% end %>
     ], strategy: :one_for_one, name: <%= @project_name_camel_case %>.Supervisor)

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/pub_sub.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/pub_sub.ex
@@ -1,4 +1,34 @@
 <% MixTemplates.ignore_file_unless(assigns[:websockets] != nil) %>
 defmodule <%= @project_name_camel_case %>.PubSub do
+  @moduledoc """
+  The realtime interface for `<%= @project_name_camel_case %>`.
+
+  ## Publishing Messages
+
+  To broadcast a message to all subscribers:
+
+      <%= @project_name_camel_case %>.PubSub.broadcast("topic", {:event, "value"})
+
+  To broadcast to all subscribers except the current process:
+
+      <%= @project_name_camel_case %>.PubSub.broadcast_from(self(), "topic", {:event, "value"})
+
+  ## Subscribing to Messages
+
+  `subscribe/1` will subscribe the current process to messages on a topic.
+
+      <%= @project_name_camel_case %>.PubSub.subscribe("topic")
+
+  Messages will go to the process's mailbox, or the `handle_info` callback if
+  the process is a `GenServer`.
+
+  ## Topics & Message Formats
+
+  TODO: document topics and message formats which are broadcasted, like so:
+
+  - topic_name
+    - `{:event_name, event_value}`: description of event type
+  """
+
   use Mithril.PubSub, otp_app: :<%= @project_name %>
 end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/config/config.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/config/config.exs
@@ -1,30 +1,3 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
-
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :<%= @project_name %>_api, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:<%= @project_name %>_api, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/application.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/application.ex
@@ -1,0 +1,20 @@
+defmodule <%= @project_name_camel_case %>API.Application do
+  @moduledoc """
+  The `<%= @project_name_camel_case %>API` OTP Application definition. This is where the
+  supervision tree for `<%= @project_name_camel_case %>API` is defined.
+  """
+
+  @doc false
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    Supervisor.start_link([
+      <%= if assigns[:websockets] do %>
+      supervisor(Absinthe.Subscription, [<%= @project_name_camel_case %>Web.Endpoint]),
+      worker(<%= @project_name_camel_case %>API.PubSub.Repeater, [<%= @project_name_camel_case %>Web.Endpoint])
+      <% else %>
+      # worker(module, args)
+      <% end %>
+    ], strategy: :one_for_one, name: <%= @project_name_camel_case %>API.Supervisor)
+  end
+end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/pub_sub/repeater.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/pub_sub/repeater.ex
@@ -1,0 +1,54 @@
+<% MixTemplates.ignore_file_and_directory_unless(assigns[:websockets] != nil) %>
+defmodule <%= @project_name_camel_case %>API.PubSub.Repeater do
+  @moduledoc """
+  Listens to `<%= @project_name_camel_case %>.PubSub`'s realtime interface and converts events 
+  on certain topics to Absinthe subscription events using 
+  `Absinthe.Subscription.publish/3`.
+
+  This allows `<%= @project_name_camel_case %>` to publish regular Elixir tuple events 
+  about realtime events which are occuring in the business logic. `<%= @project_name_camel_case %>API`
+  can pick up on those events and broadcast them the way GraphQL expects.
+
+  The flow works like this:
+
+  1. Client submits a mutation to `<%= @project_name_camel_case %>API.Schema`
+
+  2. Mutation resolver calls a function on `<%= @project_name_camel_case %>`, which, if successful,
+     broadcasts a regular Elixir event on a topic on `<%= @project_name_camel_case %>.PubSub`.
+
+     - Domains within `<%= @project_name_camel_case %>` can also be subscribing to these
+       events for activity feeds, analytics, logging, reporting, etc.
+
+  3. `<%= @project_name_camel_case %>API.PubSub.Repeater` picks up on the event, and repeats it
+     on `<%= @project_name_camel_case %>.PubSub %>`, but on an Absinthe-specific topic, and in
+     the format that only Absinthe/Phoenix expects.
+
+  This keeps the Absinthe-specific subscription details local to `<%= @project_name_camel_case %>API`,
+  allowing `<%= @project_name_camel_case %>` to have zero knowledge or dependency on Phoenix or GraphQL.
+  """
+
+  use GenServer
+
+  alias <%= @project_name_camel_case %>.PubSub, warn: false
+  alias Absinthe.Subscription, warn: false
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  @doc false
+  def init(target) do
+    # PubSub.subscribe("topic1")
+    # PubSub.subscribe("topic2")
+    {:ok, target}
+  end
+
+  # Each message broadcasted on the watched topics will trigger a handle_info
+  # callback like the one below, where `target` is the PubSub server that
+  # Absinthe will use.
+  #
+  # def handle_info({:user_created, user}, target) do
+  #   Subscription.publish(target, user, user_created: "*")
+  #   {:noreply, target}
+  # end
+end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/types/sample.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/lib/$PROJECT_NAME$_api/types/sample.ex
@@ -11,6 +11,8 @@ defmodule <%= @project_name_camel_case %>API.Types.Sample do
         import_fields :sample_queries
       end
   """
+  
+  use Absinthe.Schema.Notation
 
   alias <%= @project_name_camel_case %>API.Resolvers
 

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/mix.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_api/mix.exs
@@ -21,6 +21,7 @@ defmodule <%= @project_name_camel_case %>API.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {<%= @project_name_camel_case %>API.Application, []},
       extra_applications: [:logger]
     ]
   end
@@ -39,7 +40,7 @@ defmodule <%= @project_name_camel_case %>API.Mixfile do
   defp deps do
     [
       {:<%= @project_name %>, in_umbrella: true},
-      {:absinthe_plug, "~> 1.3.0"},
+      {:absinthe_plug, "~> 1.4.0"},
       {:poison, "~> 3.1"}
     ]
   end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web.ex
@@ -60,22 +60,21 @@ defmodule <%= @project_name_camel_case %>Web do
   def channel do
     quote do
       use Phoenix.Channel
-      <%= if assigns[:gettext] do %>import <%= @project_name_camel_case %>Web.Gettext<% end %>
+      <%= if assigns[:gettext] do %>
 
+      import <%= @project_name_camel_case %>Web.Gettext
+      <% end %>
+
+      # Channels should not broadcast events directly. Instead,
+      # they should call functions on `<%= @project_name_camel_case %>` and let
+      # those functions internally broadcast messages on `<%= @project_name_camel_case %>.PubSub` 
+      # as they see fit.
       import Phoenix.Channel,
         except: [
           broadcast: 3,
           broadcast!: 3,
           broadcast_from: 3,
           broadcast_from!: 3
-        ]
-
-      import <%= @project_name_camel_case %>.PubSub,
-        only: [
-          broadcast: 2,
-          broadcast!: 2,
-          broadcast_from: 2,
-          broadcast_from!: 2
         ]
     end
   end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/channels/user_socket.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/channels/user_socket.ex
@@ -1,6 +1,9 @@
 <% MixTemplates.ignore_file_and_directory_unless(assigns[:websockets]) %>
 defmodule <%= @project_name_camel_case %>Web.UserSocket do
   use Phoenix.Socket
+  <%= if assigns[:websockets] && assigns[:api] == "graphql" do %>
+  use Absinthe.Phoenix.Socket, schema: <%= @project_name_camel_case %>API.Schema
+  <% end %>
 
   ## Channels
   # channel "room:*", <%= @project_name_camel_case %>Web.RoomChannel

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/endpoint.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/endpoint.ex
@@ -4,6 +4,9 @@ defmodule <%= @project_name_camel_case %>Web.Endpoint do
   """
 
   use Phoenix.Endpoint, otp_app: :<%= @project_name %>_web
+  <%= if assigns[:websockets] && assigns[:api] == "graphql" do %>
+  use Absinthe.Phoenix.Endpoint
+  <% end %>
 
   <%= if assigns[:websockets] do %>
   socket "/socket", <%= @project_name_camel_case %>Web.UserSocket

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/router.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/router.ex
@@ -40,7 +40,10 @@ defmodule <%= @project_name_camel_case %>Web.Router do
     pipe_through :api
 
     forward "/api", Absinthe.Plug, schema: <%= @project_name_camel_case %>API.Schema
-    forward "/graphiql", Absinthe.Plug.GraphiQL, schema: <%= @project_name_camel_case %>API.Schema
+    forward "/graphiql", Absinthe.Plug.GraphiQL, 
+      schema: <%= @project_name_camel_case %>API.Schema<%= if assigns[:websockets] do %>,
+      socket: <%= @project_name_camel_case %>Web.UserSocket
+      <% end %>
   end
   <% end %>
   <%= if assigns[:html] do %>

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/mix.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/mix.exs
@@ -49,7 +49,8 @@ defmodule <%= @project_name_camel_case %>Web.Mixfile do
       {:phoenix_ecto, "~> 3.2"},<% end %><%= if assigns[:html] do %>
       {:phoenix_html, "~> 2.10"},<% end %><%= if assigns[:html] == "slim" do %>
       {:phoenix_slime, "~> 0.8.0"},<% end %>
-      {:phoenix_live_reload, "~> 1.0", only: :dev},<%= if assigns[:gettext] do %>
+      {:phoenix_live_reload, "~> 1.0", only: :dev},<%= if assigns[:websockets] && assigns[:api] == "graphql" do %>
+      {:absinthe_phoenix, "~> 1.4.0"},<% end %><%= if assigns[:gettext] do %>
       {:gettext, "~> 0.11"},<% end %>
       {:<%= @project_name %>, in_umbrella: true},
       {:cowboy, "~> 1.0"}<%= if assigns[:email] do %>,


### PR DESCRIPTION
I figured out how to make GraphQL a client on the logic app's PubSub
interface. The API app simply listens to topics, and when appropriate,
repeats the messages in a way that will cause them to propagate as
websocket notifications.