### PR TITLE
Update bin/test, bin/update

### DIFF
--- a/lib/mithril.ex
+++ b/lib/mithril.ex
@@ -62,7 +62,7 @@ defmodule Mithril do
     ]
 
   def clean_up(context) do
-    if context[:elixir_version] =~ "1.6" do
+    if Version.match?(context[:elixir_version], "~> 1.6") do
       IO.puts("Running code formatter...")
       System.cmd("mix", ["format"], cd: context[:target_subdir])
     end

--- a/template/$PROJECT_NAME$/bin/test
+++ b/template/$PROJECT_NAME$/bin/test
@@ -3,6 +3,9 @@
 # Test Script
 #
 # Runs all commands needed to fully test the application.
+<%= if Version.match?(System.version(), "~> 1.6") do %>
+MIX_ENV=test mix format --check-formatted || { echo 'Some files were not formatted!'; exit 1; }
+<% end %>
 MIX_ENV=test mix compile --warnings-as-errors --force || { echo 'Please fix all compiler warnings.'; exit 1; }
 MIX_ENV=test mix docs || { echo 'Elixir HTML docs were not generated!'; exit 1; }
 mix test || { echo 'Elixir tests failed!'; exit 1; }

--- a/template/$PROJECT_NAME$/bin/update
+++ b/template/$PROJECT_NAME$/bin/update
@@ -8,5 +8,8 @@
 git pull || { echo 'Could not pull from origin.'; exit 1; }
 mix deps.get || { echo 'Could not update dependencies.'; exit 1; }
 mix compile || { echo 'Could not compile app.'; exit 1; }
+<%= if assigns[:ecto] do %>
+mix ecto.migrate || { echo 'Migrations failed!'; exit 1; }
+<% end %>
 
 echo "Update complete!"


### PR DESCRIPTION
Both these scripts needed small tweaks to do everything they were
supposed to do.

I added `mix format --check-formatted` to bin/test to ensure that the
codebase stays well formatted after the initial format.