### PR TITLE
[#20] Generate Content Security Policy

### DIFF
--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/router.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/router.ex
@@ -8,12 +8,22 @@ defmodule <%= @project_name_camel_case %>Web.Router do
   <% end %>
   <%= if assigns[:html] || assigns[:email] do %>
 
+  # This is your site's content security policy. Read more here:
+  # https://www.w3.org/TR/CSP2/
+  @csp [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "form-action 'self'",
+    "default-src 'self'"
+  ] |> Enum.join(";")
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
     plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug :put_secure_browser_headers, %{"content-security-policy" => @csp}
     <%= if assigns[:accounts] && assigns[:html] do %>
     plug :load_token
     <% end %>


### PR DESCRIPTION
Per #20. This policy will lock down everything, except inline styles.
You'll still be able to use `style='...'` declarations.

Fixes #20.