### PR TITLE
Password length validation & Error Interpolation

### DIFF
--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/accounts/user.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$/lib/$PROJECT_NAME$/accounts/user.ex
@@ -28,7 +28,7 @@ defmodule <%= @project_name_camel_case %>.Accounts.User do
 
   **Do not** create Ecto associations between this schema and schemas in other
   domains. This preserves the separation of the domains and enforces that
-  all queries be made through a public domain function. 
+  all queries be made through a public domain function.
   """
 
   use Ecto.Schema
@@ -60,12 +60,14 @@ defmodule <%= @project_name_camel_case %>.Accounts.User do
 
   defp validate_password(%{data: %{id: id}} = changeset) when id != nil do
     changeset
+    |> validate_length(:password, min: 8)
     |> validate_confirmation(:password)
   end
 
   defp validate_password(changeset) do
     changeset
     |> validate_required([:password, :password_confirmation])
+    |> validate_length(:password, min: 8)
     |> validate_confirmation(:password)
   end
 

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/views/error_helpers.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/lib/$PROJECT_NAME$_web/views/error_helpers.ex
@@ -6,7 +6,6 @@ defmodule <%= @project_name_camel_case %>Web.ErrorHelpers do
 
   use Phoenix.HTML
 
-  <%= if assigns[:gettext] do %>
   @doc """
   Generates tag for inlined form input errors.
   """
@@ -16,6 +15,7 @@ defmodule <%= @project_name_camel_case %>Web.ErrorHelpers do
     end)
   end
 
+  <%= if assigns[:gettext] do %>
   @doc """
   Translates an error message using gettext.
   """
@@ -45,11 +45,11 @@ defmodule <%= @project_name_camel_case %>Web.ErrorHelpers do
   end
   <% else %>
   @doc """
-  Generates tag for inlined form input errors.
+  Interpolates an error message using String.replace/3
   """
-  def error_tag(form, field) do
-    Enum.map(Keyword.get_values(form.errors, field), fn ({msg, _opts}) ->
-      content_tag :span, msg, class: "help-block"
+  def translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
     end)
   end
   <% end %>

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/$PROJECT_NAME$_web/controllers/accounts/reset_password_controller_test.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/$PROJECT_NAME$_web/controllers/accounts/reset_password_controller_test.exs
@@ -68,19 +68,36 @@ defmodule <%= @project_name_camel_case %>Web.Accounts.ResetPasswordControllerTes
 
     test "validates password confirmation", %{conn: conn, token: token} do
       params = %{
-        "token" => token, 
+        "token" => token,
         "user" => %{
           "password" => "password",
           "password_confirmation" => "mismatch"
         }
       }
 
-      response = 
+      response =
         conn
         |> post(Routes.reset_password_path(conn, :create), params)
         |> html_response(400)
 
       assert response =~ "does not match confirmation"
+    end
+
+    test "validates password min length", %{conn: conn, token: token} do
+      params = %{
+        "token" => token,
+        "user" => %{
+          "password" => "pass",
+          "password_confirmation" => "pass"
+        }
+      }
+
+      response =
+        conn
+        |> post(Routes.reset_password_path(conn, :create), params)
+        |> html_response(400)
+
+      assert response =~ "should be at least 8 character(s)"
     end
   end
 


### PR DESCRIPTION
When not using gettext, ecto changeset errors that are meant to be interpolated were not formatted properly.

![screen shot 2018-01-18 at 12 07 34 pm](https://user-images.githubusercontent.com/1761481/35120452-1a62bcbe-fc90-11e7-9891-6afae00e2f10.png)

This PR adds a min length validation of 8 characters to the user, and updates the `ErrorHelpers` module to differ only in the `translate_error/1` function (depending on whether the gettext opt is passed). Gettext will handle the interpolation automatically, but we need to do it manually otherwise.

Test case included. :smile: 


