### PR TITLE
[#14] Support Hound

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ any of the libraries listed below.
 | [Absinthe](https://absinthe-graphql.org)                         | Yes      | GraphQL APIs (for mobile apps) |
 | [Phoenix](https://phoenixframework.org)                          | Yes      | HTTP/Websocket support         |
 | [Webpack](https://webpack.js.org/) / [Brunch](http://brunch.io/) | Yes      | Front-end assets (JS/CSS)      |
+| [Hound](https://hex.pm/packages/hound)                           | Yes      | In-browser integration tests   |
 
 ## Install
 

--- a/bin/test
+++ b/bin/test
@@ -13,7 +13,7 @@ mix archive.install hex mix_generator --force || { echo 'Could not install mix_g
 mix archive.install hex mix_templates --force || { echo 'Could not install mix_templates!'; exit 1; }
 
 # Generate a kitchen sink app and test it
-mix gen ./ kitchen_sink --ecto postgres --email --accounts --assets --asset-bundler webpack --api graphql --html slim --ci semaphore --websockets --error-reporting honeybadger --deploy heroku --gettext || { echo 'KitchenSink app could not be generated'; exit 1; }
+mix gen ./ kitchen_sink --ecto postgres --email --accounts --assets --asset-bundler webpack --api graphql --html slim --ci semaphore --websockets --error-reporting honeybadger --deploy heroku --gettext --integration hound || { echo 'KitchenSink app could not be generated'; exit 1; }
 
 cd kitchen_sink && {
   bin/setup || { echo 'KitchenSink could not be set up!'; exit 1; }

--- a/guides/introduction/generating.md
+++ b/guides/introduction/generating.md
@@ -49,6 +49,10 @@ application. Use the options below to add functionality.
   * `eex`
   * `slim` via [Slime](http://slime-lang.com/)
 
+* `--integration [library]`: Generates in-browser integration test supporting files and a sample test.
+
+  * [`hound`](https://hex.pm/packages/hound)
+
 * `--sass-syntax [syntax]`: The variant of [Sass](http://sass-lang.com) syntax to use if you have an asset pipeline. Supported options:
 
   * `sass`

--- a/lib/mithril.ex
+++ b/lib/mithril.ex
@@ -51,6 +51,9 @@ defmodule Mithril do
       # Takes "slim", "eex"
       html: [takes: "slim or eex"],
 
+      # String, what library to use for in-browser integration testing
+      integration: [takes: "hound"],
+
       # If --assets, which Sass syntax to use:
       #
       # Example: --sass-syntax scss

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/config/test.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/config/test.exs
@@ -1,7 +1,9 @@
 use Mix.Config
 
-# We don't run a server during test. If one is required,
-# you can enable the server option below.
 config :<%= @project_name %>_web, <%= @project_name_camel_case %>Web.Endpoint,
   http: [port: 4001],
-  server: false
+  server: <%= assigns[:integration] != nil %>
+
+<%= if assigns[:integration] == "hound" do %>
+config :hound, driver: "chrome_driver"
+<% end %>

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/mix.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/mix.exs
@@ -69,6 +69,9 @@ defmodule <%= @project_name_camel_case %>Web.Mixfile do
       <%= if assigns[:api] do %>
       {:<%= @project_name %>_api, in_umbrella: true},
       <% end %>
+      <%= if assigns[:integration] == "hound" do %>
+      {:hound, "~> 1.0", only: :test},
+      <% end %>
       {:cowboy, "~> 1.0"},
       <%= if assigns[:email] do %>
       {:swoosh, "~> 0.11.0"} # For mailbox preview plug

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/$PROJECT_NAME$_web/integration/page_test.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/$PROJECT_NAME$_web/integration/page_test.exs
@@ -1,0 +1,8 @@
+defmodule <%= @project_name_camel_case %>Web.PageTest do
+  use <%= @project_name_camel_case %>Web.IntegrationCase
+
+  test "home page loads" do
+    navigate_to("/")
+    assert page_source() =~ "<%= @project_name_camel_case %>"
+  end
+end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/support/integration_case.ex
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/support/integration_case.ex
@@ -1,0 +1,23 @@
+<%= MixTemplates.ignore_file_unless(assigns[:integration] == "hound") %>
+defmodule <%= @project_name_camel_case %>Web.IntegrationCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require a full, in-browser integration
+  test.
+
+  Relies on `<%= @project_name_camel_case %>Web.ConnCase`.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use <%= @project_name_camel_case %>Web.ConnCase
+      use Hound.Helpers
+
+      @moduletag :integration
+
+      hound_session()
+    end
+  end
+end

--- a/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/test_helper.exs
+++ b/template/$PROJECT_NAME$/apps/$PROJECT_NAME$_web/test/test_helper.exs
@@ -1,5 +1,9 @@
 ExUnit.start()
 
+<%= if assigns[:integration] == "hound" do %>
+Application.ensure_all_started(:hound)
+<% end %>
+
 <%= if assigns[:ecto] == "postgres" do %>
 Ecto.Adapters.SQL.Sandbox.mode(<%= @project_name_camel_case %>.Repo, :manual)
 <% end %>

--- a/template/$PROJECT_NAME$/bin/setup
+++ b/template/$PROJECT_NAME$/bin/setup
@@ -14,6 +14,15 @@ command -v elixir >/dev/null 2>&1 || {
   exit 1
 }
 
+<%= if assigns[:integration] == "hound" do %>
+# Ensure Chromedriver is installed
+command -v chromedriver >/dev/null 2>&1 || {
+  echo "This app requires Chrome Driver for integration testing."
+  echo "Install it using the instructions at https://sites.google.com/a/chromium.org/chromedriver/downloads"
+  exit 1
+}
+<% end %>
+
 <%= if assigns[:assets] do %>
 # Ensure Node.js is installed
 command -v npm >/dev/null 2>&1 || {

--- a/template/$PROJECT_NAME$/bin/test
+++ b/template/$PROJECT_NAME$/bin/test
@@ -3,10 +3,16 @@
 # Test Script
 #
 # Runs all commands needed to fully test the application.
+<%= if assigns[:integration] == "hound" do %>
+# Automatically start Chrome Driver in the background
+chromedriver &
+
+# Automatically kill Chrome Driver after script exits
+trap 'jobs -p | xargs kill' EXIT
+<% end %>
 <%= if Version.match?(System.version(), "~> 1.6") do %>
 MIX_ENV=test mix format --check-formatted || { echo 'Some files were not formatted!'; exit 1; }
 <% end %>
 MIX_ENV=test mix compile --warnings-as-errors --force || { echo 'Please fix all compiler warnings.'; exit 1; }
 MIX_ENV=test mix docs || { echo 'Elixir HTML docs were not generated!'; exit 1; }
 mix test || { echo 'Elixir tests failed!'; exit 1; }
-


### PR DESCRIPTION
Adds a `--integration hound` generator option which will:

- Add a check to the `bin/setup` script for `webdriver`
- Configure Hound to use Chrome WebDriver (the only reliable driver
we've found, in our experience)
- Create an `IntegrationCase`
- Create a sample test on the home page
- Update `bin/test` to automatically start/stop WebDriver

Closes #14.